### PR TITLE
Preserve original filenames for images and documents

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -56,11 +56,17 @@ module.exports = {
       },
       {
         test: /\.(png|svg|jpg|gif)$/,
-        loader: "file-loader"
+        loader: "file-loader",
+        options: {
+          name: "[name].[ext]"
+        }
       },
       {
         test: /\.(pdf|docx)$/,
-        loader: "file-loader"
+        loader: "file-loader",
+        options: {
+          name: "[name].[ext]"
+        }
       },
       {
         test: /\.(woff|woff2|eot|ttf|otf)$/,


### PR DESCRIPTION
So resumes and images can be downloaded and viewed with accurate
filenames